### PR TITLE
Allow subclassing

### DIFF
--- a/src/Arduino_ESP32_OTA.cpp
+++ b/src/Arduino_ESP32_OTA.cpp
@@ -37,6 +37,7 @@ Arduino_ESP32_OTA::Arduino_ESP32_OTA()
 ,_crc32(0)
 ,_ca_cert{amazon_root_ca}
 ,_ca_cert_bundle{nullptr}
+,_magic(0)
 {
 
 }
@@ -45,7 +46,7 @@ Arduino_ESP32_OTA::Arduino_ESP32_OTA()
    PUBLIC MEMBER FUNCTIONS
  ******************************************************************************/
 
-Arduino_ESP32_OTA::Error Arduino_ESP32_OTA::begin()
+Arduino_ESP32_OTA::Error Arduino_ESP32_OTA::begin(uint32_t magic)
 {
   /* initialize private variables */
   otaInit();
@@ -53,6 +54,8 @@ Arduino_ESP32_OTA::Error Arduino_ESP32_OTA::begin()
   /* ... initialize CRC ... */
   crc32Init();
 
+  /* ... configure board Magic number */
+  setMagic(magic);
 
   if(Update.isRunning()) {
     Update.abort();
@@ -78,6 +81,11 @@ void Arduino_ESP32_OTA::setCACertBundle (const uint8_t * bundle)
   if(bundle != nullptr) {
     _ca_cert_bundle = bundle;
   }
+}
+
+void Arduino_ESP32_OTA::setMagic(uint32_t magic)
+{
+  _magic = magic;
 }
 
 uint8_t Arduino_ESP32_OTA::read_byte_from_network()
@@ -235,7 +243,7 @@ int Arduino_ESP32_OTA::download(const char * ota_url)
   }
 
   /* ... and OTA magic number */
-  if (_ota_header.header.magic_number != ARDUINO_ESP32_OTA_MAGIC)
+  if (_ota_header.header.magic_number != _magic)
   {
     delete _client;
     _client = nullptr;

--- a/src/Arduino_ESP32_OTA.cpp
+++ b/src/Arduino_ESP32_OTA.cpp
@@ -26,26 +26,6 @@
 #include "decompress/utility.h"
 #include "esp_ota_ops.h"
 
-/* Used to bind local module function to actual class instance */
-static Arduino_ESP32_OTA * _esp_ota_obj_ptr = 0;
-
-/******************************************************************************
-   LOCAL MODULE FUNCTIONS
- ******************************************************************************/
-
-static uint8_t read_byte() {
-  if(_esp_ota_obj_ptr) {
-    return _esp_ota_obj_ptr->read_byte_from_network();
-  }
-  return -1;
-}
-
-static void write_byte(uint8_t data) {
-  if(_esp_ota_obj_ptr) {
-    _esp_ota_obj_ptr->write_byte_to_flash(data);
-  }
-}
-
 /******************************************************************************
    CTOR/DTOR
  ******************************************************************************/
@@ -67,7 +47,6 @@ Arduino_ESP32_OTA::Arduino_ESP32_OTA()
 
 Arduino_ESP32_OTA::Error Arduino_ESP32_OTA::begin()
 {
-  _esp_ota_obj_ptr = this;
 
   /* ... initialize CRC ... */
   _crc32 = 0xFFFFFFFF;
@@ -268,7 +247,7 @@ int Arduino_ESP32_OTA::download(const char * ota_url)
   _crc32 = crc_update(_crc32, &_ota_header.header.magic_number, 12);
 
   /* Download and decode OTA file */
-  _ota_size = lzss_download(read_byte, write_byte, content_length_val - sizeof(_ota_header));
+  _ota_size = lzss_download(this, content_length_val - sizeof(_ota_header));
 
   if(_ota_size <= content_length_val - sizeof(_ota_header))
   {

--- a/src/Arduino_ESP32_OTA.cpp
+++ b/src/Arduino_ESP32_OTA.cpp
@@ -75,7 +75,12 @@ Arduino_ESP32_OTA::Error Arduino_ESP32_OTA::begin()
   /* initialize private variables */
   _ota_size = 0;
   _ota_header = {0};
-  
+
+  if(Update.isRunning()) {
+    Update.abort();
+    DEBUG_DEBUG("%s: Aborting running update", __FUNCTION__);
+  }
+
   if(!Update.begin(UPDATE_SIZE_UNKNOWN)) {
     DEBUG_ERROR("%s: failed to initialize flash update", __FUNCTION__);
     return Error::OtaStorageInit;

--- a/src/Arduino_ESP32_OTA.cpp
+++ b/src/Arduino_ESP32_OTA.cpp
@@ -146,6 +146,8 @@ int Arduino_ESP32_OTA::download(const char * ota_url)
   if (!_client->connect(url.host_.c_str(), port))
   {
     DEBUG_ERROR("%s: Connection failure with OTA storage server %s", __FUNCTION__, url.host_.c_str());
+    delete _client;
+    _client = nullptr;
     return static_cast<int>(Error::ServerConnectError);
   }
 
@@ -176,6 +178,8 @@ int Arduino_ESP32_OTA::download(const char * ota_url)
   if (!is_header_complete)
   {
     DEBUG_ERROR("%s: Error receiving HTTP header %s", __FUNCTION__, is_http_header_timeout ? "(timeout)":"");
+    delete _client;
+    _client = nullptr;
     return static_cast<int>(Error::HttpHeaderError);
   }
 
@@ -206,6 +210,8 @@ int Arduino_ESP32_OTA::download(const char * ota_url)
   if (!content_length_ptr)
   {
     DEBUG_ERROR("%s: Failure to extract content length from http header", __FUNCTION__);
+    delete _client;
+    _client = nullptr;
     return static_cast<int>(Error::ParseHttpHeader);
   }
   /* Find start of numerical value. */
@@ -233,17 +239,23 @@ int Arduino_ESP32_OTA::download(const char * ota_url)
 
   /* ... check for header download timeout ... */
   if (is_ota_header_timeout) {
+    delete _client;
+    _client = nullptr;
     return static_cast<int>(Error::OtaHeaderTimeout);
   }
 
   /* ... then check if OTA header length field matches HTTP content length... */
   if (_ota_header.header.len != (content_length_val - sizeof(_ota_header.header.len) - sizeof(_ota_header.header.crc32))) {
+    delete _client;
+    _client = nullptr;
     return static_cast<int>(Error::OtaHeaderLength);
   }
 
   /* ... and OTA magic number */
   if (_ota_header.header.magic_number != ARDUINO_ESP32_OTA_MAGIC)
   {
+    delete _client;
+    _client = nullptr;
     return static_cast<int>(Error::OtaHeaterMagicNumber);
   }
 
@@ -255,9 +267,13 @@ int Arduino_ESP32_OTA::download(const char * ota_url)
 
   if(_ota_size <= content_length_val - sizeof(_ota_header))
   {
+    delete _client;
+    _client = nullptr;
     return static_cast<int>(Error::OtaDownload);
   }
 
+  delete _client;
+  _client = nullptr;
   return _ota_size;
 }
 

--- a/src/Arduino_ESP32_OTA.cpp
+++ b/src/Arduino_ESP32_OTA.cpp
@@ -71,6 +71,10 @@ Arduino_ESP32_OTA::Error Arduino_ESP32_OTA::begin()
 
   /* ... initialize CRC ... */
   _crc32 = 0xFFFFFFFF;
+
+  /* initialize private variables */
+  _ota_size = 0;
+  _ota_header = {0};
   
   if(!Update.begin(UPDATE_SIZE_UNKNOWN)) {
     DEBUG_ERROR("%s: failed to initialize flash update", __FUNCTION__);

--- a/src/Arduino_ESP32_OTA.h
+++ b/src/Arduino_ESP32_OTA.h
@@ -78,7 +78,7 @@ public:
   void setCACertBundle(const uint8_t * bundle);
   int download(const char * ota_url);
   uint8_t read_byte_from_network();
-  void write_byte_to_flash(uint8_t data);
+  virtual void write_byte_to_flash(uint8_t data);
   Arduino_ESP32_OTA::Error update();
   void reset();
 

--- a/src/Arduino_ESP32_OTA.h
+++ b/src/Arduino_ESP32_OTA.h
@@ -81,8 +81,15 @@ public:
   Arduino_ESP32_OTA::Error update();
   void reset();
 
-private:
+protected:
 
+  void otaInit();
+  void crc32Init();
+  void crc32Update(const uint8_t data);
+  void crc32Finalize();
+  bool crc32Verify();
+
+private:
   Client * _client;
   OtaHeader _ota_header;
   size_t _ota_size;

--- a/src/Arduino_ESP32_OTA.h
+++ b/src/Arduino_ESP32_OTA.h
@@ -72,8 +72,9 @@ public:
            Arduino_ESP32_OTA();
   virtual ~Arduino_ESP32_OTA() { }
 
-  Arduino_ESP32_OTA::Error begin();
-  void setCACert (const char *rootCA);
+  Arduino_ESP32_OTA::Error begin(uint32_t magic = ARDUINO_ESP32_OTA_MAGIC);
+  void setMagic(uint32_t magic);
+  void setCACert(const char *rootCA);
   void setCACertBundle(const uint8_t * bundle);
   int download(const char * ota_url);
   uint8_t read_byte_from_network();
@@ -96,6 +97,8 @@ private:
   uint32_t _crc32;
   const char * _ca_cert;
   const uint8_t * _ca_cert_bundle;
+  uint32_t _magic;
+
 };
 
 #endif /* ARDUINO_ESP32_OTA_H_ */

--- a/src/Arduino_ESP32_OTA.h
+++ b/src/Arduino_ESP32_OTA.h
@@ -43,13 +43,6 @@ static uint32_t const ARDUINO_ESP32_OTA_BINARY_HEADER_RECEIVE_TIMEOUT_ms = 10000
 static uint32_t const ARDUINO_ESP32_OTA_BINARY_BYTE_RECEIVE_TIMEOUT_ms = 2000;
 
 /******************************************************************************
- * TYPEDEF
- ******************************************************************************/
-
-typedef uint8_t(*ArduinoEsp32OtaReadByteFuncPointer)(void);
-typedef void(*ArduinoEsp32OtaWriteByteFuncPointer)(uint8_t);
-
-/******************************************************************************
  * CLASS DECLARATION
  ******************************************************************************/
 

--- a/src/decompress/lzss.cpp
+++ b/src/decompress/lzss.cpp
@@ -30,6 +30,7 @@ int bit_buffer = 0, bit_mask = 128;
 unsigned char buffer[N * 2];
 
 static size_t bytes_written_fputc = 0;
+static size_t bytes_read_fgetc = 0;
 
 /**************************************************************************************
    PRIVATE FUNCTIONS
@@ -45,8 +46,6 @@ void lzss_fputc(int const c)
 
 int lzss_fgetc()
 {
-  static size_t bytes_read_fgetc = 0;
-
   /* lzss_file_size is set within SSUBoot:main 
    * and contains the size of the LZSS file. Once
    * all those bytes have been read its time to return
@@ -163,6 +162,8 @@ int lzss_download(ArduinoEsp32OtaReadByteFuncPointer read_byte, ArduinoEsp32OtaW
   read_byte_fptr = read_byte;
   write_byte_fptr = write_byte;
   LZSS_FILE_SIZE = lzss_file_size;
+  bytes_written_fputc = 0;
+  bytes_read_fgetc = 0;
   lzss_decode();
   return bytes_written_fputc;
 }

--- a/src/decompress/lzss.h
+++ b/src/decompress/lzss.h
@@ -11,6 +11,6 @@
    FUNCTION DEFINITION
  **************************************************************************************/
 
-int lzss_download(ArduinoEsp32OtaReadByteFuncPointer read_byte, ArduinoEsp32OtaWriteByteFuncPointer write_byte, size_t const lzss_file_size);
+int lzss_download(Arduino_ESP32_OTA * instance, size_t const lzss_file_size);
 
 #endif /* SSU_LZSS_H_ */


### PR DESCRIPTION
- Clear lzss static variables at download start
- Initialize _ota variables inside begin function
- Make sure _client is deleted returning from download function
- Check if an update process is up and running before begin a new one
- Move instance pointer to lzss_download function
- Squashme: ensure client is deleted
- Squashme: check if no update is running before
- Add protected methods to init variables and handle crc
- Make magic number configurable
- Make write_byte_to_flash virtual
